### PR TITLE
Add logs to the capture notifications action

### DIFF
--- a/src/Payum/Nexi/Action/StatusAction.php
+++ b/src/Payum/Nexi/Action/StatusAction.php
@@ -24,23 +24,33 @@ final class StatusAction implements ActionInterface
         $details = ArrayObject::ensureArrayObject($request->getModel());
 
         if (count($details->getArrayCopy()) === 0) {
+            $this->logger->warning('HTTP Request has not payment details');
+
             return;
         }
 
         if ($details->get('esito') === Result::OUTCOME_OK) {
+            $this->logger->info(
+                'Nexi payment status is ok.',
+                $details->getArrayCopy()
+            );
             $request->markCaptured();
 
             return;
         }
 
         if ($details->get('esito') === Result::OUTCOME_ANNULLO) {
+            $this->logger->notice(
+                'Nexi payment status is cancelled.',
+                $details->getArrayCopy()
+            );
             $request->markCanceled();
 
             return;
         }
 
         if (in_array($details->get('esito'), [Result::OUTCOME_KO, Result::OUTCOME_ERRORE], true)) {
-            $this->logger->error(
+            $this->logger->warning(
                 'Nexi payment status is not ok or canceled and will be marked as failed.',
                 $details->getArrayCopy()
             );
@@ -49,7 +59,10 @@ final class StatusAction implements ActionInterface
             return;
         }
 
-        $this->logger->error('Nexi payment status is invalid and will be marked as unknown.', $details->getArrayCopy());
+        $this->logger->warning(
+            'Nexi payment status is invalid and will be marked as unknown.',
+            $details->getArrayCopy()
+        );
         $request->markUnknown();
     }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="webgriffe_sylius_nexi.lib.signer" />
             <argument type="service" id="webgriffe_sylius_nexi.lib.checker" />
             <argument type="service" id="webgriffe_sylius_nexi.decoder.request_params"/>
+            <argument type="service" id="webgriffe_sylius_nexi.logger" />
         </service>
 
         <service id="webgriffe_sylius_nexi.lib.signer" class="Webgriffe\LibQuiPago\Signature\DefaultSigner">


### PR DESCRIPTION
To be able to get more information when a payment does not receive the S2S confirmation I have added logs to the capture notifications action.